### PR TITLE
Start Kubernetes addons only after Ceph mon is initialized

### DIFF
--- a/iso/controller/airootfs/etc/systemd/system/start-addons.service
+++ b/iso/controller/airootfs/etc/systemd/system/start-addons.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kubernetes add-ons
 Requires=kubelet.service
-After=kubelet.service
+After=kubelet.service operos-ceph-mon-init.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The start-addons script depends on ceph mon initialization