### PR TITLE
statustty reacts properly to terminal resize

### DIFF
--- a/iso/controller/airootfs/etc/systemd/system/statustty.service
+++ b/iso/controller/airootfs/etc/systemd/system/statustty.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=TTY status display
 After=systemd-journald.service
+DefaultDependencies=no
 
 [Service]
 EnvironmentFile=/etc/paxautoma/settings

--- a/iso/controller/airootfs/etc/systemd/system/statustty.service
+++ b/iso/controller/airootfs/etc/systemd/system/statustty.service
@@ -13,7 +13,6 @@ TTYPath=/dev/tty1
 TTYReset=yes
 TTYVHangup=yes
 TTYVTDisallocate=yes
-KillMode=none
 
 # Unset locale for the console getty since the console has problems
 # displaying some internationalized messages.

--- a/iso/worker/airootfs/etc/systemd/system/statustty.service
+++ b/iso/worker/airootfs/etc/systemd/system/statustty.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=TTY status display
 After=systemd-journald.service
+DefaultDependencies=no
 
 [Service]
 ExecStart=-/sbin/agetty --noclear -o "--boot-if --node-type Worker" -l /usr/bin/statustty -n tty1 $TERM

--- a/iso/worker/airootfs/etc/systemd/system/statustty.service
+++ b/iso/worker/airootfs/etc/systemd/system/statustty.service
@@ -12,7 +12,6 @@ TTYPath=/dev/tty1
 TTYReset=yes
 TTYVHangup=yes
 TTYVTDisallocate=yes
-KillMode=none
 
 # Unset locale for the console getty since the console has problems
 # displaying some internationalized messages.


### PR DESCRIPTION
Previously, it would not properly refresh the size of the view, resulting in artifacts. This would occur, for example, if statustty started before the kernel changes the console resolution part-way through booting. The end result was like the image in our docs:

![Resizing issue](https://www.paxautoma.com/operos/docs/images/0.1.0/ctrlstatustty.png)

This change also removes the default systemd dependencies from statustty to make it start sooner in the boot process and stop later in the shutdown process.