### PR TITLE
Single NIC mode

### DIFF
--- a/components/installer/pkg/context.go
+++ b/components/installer/pkg/context.go
@@ -38,6 +38,7 @@ type InstallerResponses struct {
 	PrivateSubnet           string
 	PodSubnet               string
 	ServiceSubnet           string
+	PrivateGateway          string
 	DNSDomain               string
 	StorageSystemPercentage int
 	ControllerDisk          string
@@ -85,6 +86,7 @@ func init() {
 	// Initialize default values in the context
 	DefaultContext.Responses.PublicNetwork.Mode = "dhcp"
 	DefaultContext.Responses.PrivateSubnet = "192.168.33.10/24"
+	DefaultContext.Responses.PrivateGateway = "192.168.33.10"
 	DefaultContext.Responses.PodSubnet = "10.10.0.0/16"
 	DefaultContext.Responses.ServiceSubnet = "10.11.0.0/16"
 	DefaultContext.Responses.DNSDomain = "cluster.local"

--- a/components/installer/pkg/screens/hwprobe.go
+++ b/components/installer/pkg/screens/hwprobe.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	"github.com/jroimartin/gocui"
-	log "github.com/sirupsen/logrus"
 	"github.com/paxautoma/operos/components/common/widgets"
 	installer "github.com/paxautoma/operos/components/installer/pkg"
 	"github.com/paxautoma/operos/components/installer/pkg/network"
+	log "github.com/sirupsen/logrus"
 )
 
 func HardwareProbeScreen(screenSet *widgets.ScreenSet, context interface{}) *widgets.Screen {
@@ -71,9 +71,9 @@ This can take up to 15 seconds`, 80, 25)
 			g.Update(func(g *gocui.Gui) error {
 				hwErrors := []string{}
 
-				if len(ifaces) < 2 {
+				if len(ifaces) < 1 {
 					hwErrors = append(hwErrors, fmt.Sprintf(
-						"Required: at least 2 physical wired interfaces. This machine has %d.",
+						"Required: at least 1 physical wired interface. This machine has %d.",
 						len(ifaces)))
 				}
 

--- a/components/installer/pkg/screens/install.go
+++ b/components/installer/pkg/screens/install.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 
 	"github.com/jroimartin/gocui"
-	log "github.com/sirupsen/logrus"
 	"github.com/paxautoma/operos/components/common"
 	"github.com/paxautoma/operos/components/common/widgets"
 	installer "github.com/paxautoma/operos/components/installer/pkg"
+	log "github.com/sirupsen/logrus"
 )
 
 func ConfirmationScreen(screenSet *widgets.ScreenSet, context interface{}) *widgets.Screen {
@@ -46,7 +46,7 @@ settings:
     Location:                     {{.OrgInfo.City}}{{if .OrgInfo.Province}}, {{.OrgInfo.Province}}{{end}}, {{.OrgInfo.Country}}
 
     Private interface:            {{.PrivateInterface}}, {{.PrivateSubnet}}
-    Public interface:             {{.PublicNetwork.Interface}}, {{.PublicIPInfo}}
+    Public interface:             {{if ne .PublicNetwork.Mode "disabled"}}{{.PublicNetwork.Interface}}, {{.PublicIPInfo}}{{else}}disabled{{end}}
     Pod subnet:                   {{.PodSubnet}}
     Service subnet:               {{.ServiceSubnet}}
 
@@ -107,6 +107,7 @@ func InstallScreen(screenSet *widgets.ScreenSet, context interface{}) *widgets.S
 		fmt.Sprintf("OPEROS_NODE_MASK=/%s", privateSubnetParts[1]),
 		fmt.Sprintf("OPEROS_POD_CIDR=%s", ctx.Responses.PodSubnet),
 		fmt.Sprintf("OPEROS_SERVICE_CIDR=%s", ctx.Responses.ServiceSubnet),
+		fmt.Sprintf("OPEROS_PRIVATE_GW=%s", ctx.Responses.PrivateGateway),
 		fmt.Sprintf("OPEROS_DNS_SERVICE_IP=%s", ctx.Responses.DNSIP),
 		fmt.Sprintf("OPEROS_DNS_DOMAIN=%s", ctx.Responses.DNSDomain),
 		fmt.Sprintf("OPEROS_WORKER_STORAGE_PERCENTAGE=%d", ctx.Responses.StorageSystemPercentage),

--- a/components/installer/pkg/screens/network.go
+++ b/components/installer/pkg/screens/network.go
@@ -114,7 +114,7 @@ will be used to access the Controller UI and API.
 
 Which interface should be used for the public network?`
 
-	items := make([]widgets.MenuItem, len(ctx.Interfaces.Ordered)-1)
+	items := make([]widgets.MenuItem, len(ctx.Interfaces.Ordered))
 	idx := 0
 	selectedIdx := -1
 	for _, iface := range ctx.Interfaces.Ordered {
@@ -126,10 +126,22 @@ Which interface should be used for the public network?`
 			idx++
 		}
 	}
+	items[idx] = &widgets.SimpleMenuItem{
+		Text:  "<disabled>",
+		Value: "",
+	}
 
 	menu := widgets.NewMenu("menu-public-ifs", items, 80, 8)
 	menu.OnSelectItem = func(item widgets.MenuItem) error {
 		smi := item.(*widgets.SimpleMenuItem)
+
+		if smi.Value == "" {
+			ctx.Responses.PublicNetwork.Mode = "disabled"
+			// force user to set the gateway for the private network
+			ctx.Responses.PrivateGateway = ""
+		} else if ctx.Responses.PublicNetwork.Mode == "disabled" {
+			ctx.Responses.PublicNetwork = installer.DefaultContext.Responses.PublicNetwork
+		}
 		ctx.Responses.PublicNetwork.Interface = smi.Value
 		return nil
 	}
@@ -144,6 +156,11 @@ Which interface should be used for the public network?`
 		return nil
 	}
 	screen.OnNext = func() error {
+		if ctx.Responses.PublicNetwork.Mode == "disabled" {
+			screenSet.Forward(2)
+			return nil
+		}
+
 		if ctx.Responses.PublicNetwork.Mode == "dhcp" && ctx.Interfaces.ByName[ctx.Responses.PublicNetwork.Interface].DhcpOffer == "" {
 			message := fmt.Sprintf(`
  A DHCP server was not detected on the network connected to %s;
@@ -354,12 +371,18 @@ func NetworkSettingsIpsScreen(screenSet *widgets.ScreenSet, context interface{})
 	screen.Message = `The following IPs and domain settings will be used for the cluster. You can
 edit the values below.`
 
+	gatewayLabel := "Gateway for workers"
+	if ctx.Responses.PublicNetwork.Mode == "disabled" {
+		gatewayLabel = "Gateway"
+	}
+
 	menu := widgets.NewEditableList("eli-ips", []*widgets.EditableListItem{
 		widgets.NewEditableListItem("Private subnet", "private-subnet", ctx.Responses.PrivateSubnet, widgets.ValidateIPNet),
 		widgets.NewEditableListItem("Pod subnet", "pod-subnet", ctx.Responses.PodSubnet, widgets.ValidateIPNet),
 		widgets.NewEditableListItem("Service subnet", "service-subnet", ctx.Responses.ServiceSubnet, widgets.ValidateIPNet),
+		widgets.NewEditableListItem(gatewayLabel, "private-gateway", ctx.Responses.PrivateGateway, widgets.ValidateIP),
 		widgets.NewEditableListItem("DNS domain", "dns-domain", ctx.Responses.DNSDomain, widgets.ValidateNotEmpty),
-	}, 80, 6)
+	}, 80, 7)
 
 	errorList := widgets.NewPar("par-errors", "")
 	errorList.Bounds = image.Rect(1, 0, 79, 3)
@@ -386,6 +409,8 @@ edit the values below.`
 			ctx.Responses.ServiceSubnet = item.Value
 		case "dns-domain":
 			ctx.Responses.DNSDomain = item.Value
+		case "private-gateway":
+			ctx.Responses.PrivateGateway = item.Value
 		}
 
 		validate()

--- a/components/installer/pkg/screens/network.go
+++ b/components/installer/pkg/screens/network.go
@@ -421,7 +421,11 @@ edit the values below.`
 	screen.Content = vl
 
 	screen.OnPrev = func() error {
-		screenSet.Back(1)
+		if ctx.Responses.PublicNetwork.Mode == "disabled" {
+			screenSet.Back(2)
+		} else {
+			screenSet.Back(1)
+		}
 		return nil
 	}
 

--- a/components/statustty/cmd/main.go
+++ b/components/statustty/cmd/main.go
@@ -37,8 +37,8 @@ import (
 
 var canExit = flag.Bool("e", false, "allow user to exit via Ctrl-C")
 var useBootIface = flag.Bool("boot-if", false, "instead of public/private settings, use the interface indicated by the BOOT_IF in the kernel command line")
-var publicIface = flag.String("public-if", "eth0", "public interface")
-var privateIface = flag.String("private-if", "eth1", "private interface")
+var publicIface = flag.String("public-if", "", "public interface")
+var privateIface = flag.String("private-if", "", "private interface")
 var kubeURL = flag.String("kube-url", "", "kubenetes API server URL")
 var nodeType = flag.String("node-type", "Controller", "type of node (Controller/Worker)")
 var debugAddr = flag.String("debug-addr", "", "enable debug server on this address")
@@ -83,23 +83,22 @@ func main() {
 			log.Fatalf("could not obtain boot interface: %v", err)
 		}
 
-		ifaces = []statustty.IfaceSpec{
-			{
-				Title:  "Private",
-				Device: bootIf,
-			},
-		}
+		ifaces = append(ifaces, statustty.IfaceSpec{
+			Title:  "Private",
+			Device: bootIf,
+		})
 	} else {
-		ifaces = []statustty.IfaceSpec{
-			{
-				Title:  "Private",
-				Device: *privateIface,
-			},
-			{
-				Title:  "Public",
-				Device: *publicIface,
-			},
-		}
+		ifaces = append(ifaces, statustty.IfaceSpec{
+			Title:  "Private",
+			Device: *privateIface,
+		})
+	}
+
+	if *publicIface != "" {
+		ifaces = append(ifaces, statustty.IfaceSpec{
+			Title:  "Public",
+			Device: *publicIface,
+		})
 	}
 
 	go func() {

--- a/components/statustty/pkg/systemd.go
+++ b/components/statustty/pkg/systemd.go
@@ -94,7 +94,7 @@ func (stats *UnitStats) Delete(name string) {
 }
 
 func (stats *UnitStats) Update(unit *dbus.UnitStatus) {
-	logrus.Debugf("unit update: %s / %s / %s", unit.Name, unit.ActiveState, unit.SubState)
+	//logrus.Debugf("unit update: %s / %s / %s", unit.Name, unit.ActiveState, unit.SubState)
 
 	stats.Delete(unit.Name)
 

--- a/iso/controller/airootfs/etc/systemd/scripts/statustty
+++ b/iso/controller/airootfs/etc/systemd/scripts/statustty
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+args="
+    --private-if ${CONTROLLER_PRIVATE_IF}
+    --node-type Controller
+    --kube-url http://localhost:8080
+"
+
+if [[ -n "${CONTROLLER_PUBLIC_IF}" ]]; then
+    args="$args --public-if ${CONTROLLER_PUBLIC_IF}"
+fi
+
+echo Running agetty with $args
+exec /sbin/agetty --noclear -o "$args" -l /usr/bin/statustty -n tty1 $TERM

--- a/iso/controller/airootfs/etc/systemd/system/statustty.service
+++ b/iso/controller/airootfs/etc/systemd/system/statustty.service
@@ -5,7 +5,7 @@ DefaultDependencies=no
 
 [Service]
 EnvironmentFile=/etc/paxautoma/settings
-ExecStart=-/sbin/agetty --noclear -o "--private-if ${CONTROLLER_PRIVATE_IF} --public-if ${CONTROLLER_PUBLIC_IF} --node-type Controller --kube-url http://localhost:8080" -l /usr/bin/statustty -n tty1 $TERM
+ExecStart=/etc/systemd/scripts/statustty
 Type=simple
 Restart=always
 RestartSec=0

--- a/iso/controller/airootfs/root/customize_airootfs.sh
+++ b/iso/controller/airootfs/root/customize_airootfs.sh
@@ -20,7 +20,6 @@ chmod 700 /root
 chown 0:0 /root
 
 # Networking
-systemctl enable nat.service
 systemctl enable systemd-networkd.service
 systemctl enable systemd-resolved.service
 

--- a/iso/installer/airootfs/root/install/050-time.sh
+++ b/iso/installer/airootfs/root/install/050-time.sh
@@ -38,6 +38,6 @@ Before=kubelet.service
 After=network-online.target
 
 [Service]
-ExecStartPre=/usr/bin/chronyd -q -u chrony
+ExecStartPre=-/usr/bin/chronyd -t 90 -q -u chrony
 TimeoutStartSec=infinity
 EOF

--- a/iso/installer/airootfs/root/install/080-network.sh
+++ b/iso/installer/airootfs/root/install/080-network.sh
@@ -23,7 +23,7 @@ Name=${CONTROLLER_PUBLIC_IF}
 [Network]
 DHCP=ipv4
 EOF
-else
+elif [ "$CONTROLLER_PUBLIC_IF_MODE" = "static" ]; then
     cat > /mnt/etc/systemd/network/10-public.network <<EOF
 [Match]
 Name=${CONTROLLER_PUBLIC_IF}
@@ -44,5 +44,14 @@ Address=${OPEROS_CONTROLLER_IP}${OPEROS_NODE_MASK}
 [Route]
 Destination=${OPEROS_SERVICE_CIDR}
 EOF
+
+if [ "$CONTROLLER_PUBLIC_IF_MODE" = "disabled" ]; then
+    cat >> /mnt/etc/systemd/network/20-private.network <<EOF
+[Route]
+Gateway=${OPEROS_PRIVATE_GW}
+EOF
+else
+    arch-chroot /mnt systemctl enable nat.service
+fi
 
 ln -sf /run/systemd/resolve/resolv.conf /mnt/etc/resolv.conf

--- a/iso/installer/airootfs/root/install/104-worker-boot.sh
+++ b/iso/installer/airootfs/root/install/104-worker-boot.sh
@@ -123,7 +123,7 @@ subnet ${CLUSTER_SN_START} netmask ${CLUSTER_SN_MASK} {
     allow booting;
     range ${CLUSTER_NODE_START} ${CLUSTER_NODE_END};
     option subnet-mask ${CLUSTER_SN_MASK};
-    option routers ${OPEROS_CONTROLLER_IP};
+    option routers ${OPEROS_PRIVATE_GW};
 
     option domain-name "${OPEROS_DNS_DOMAIN}";
     option domain-search "${OPEROS_DNS_DOMAIN}";


### PR DESCRIPTION
Allow the controller to only have a single network interface. This change also adds the option to set a custom gateway for the private network.

The following network topology is supported:

```
                  +------------+
              +---+ Controller |
              |   +------------+
              |
+--------+    |   +------------+
| Router +--------+   Worker   |
+--------+    |   +------------+
              |
              |   +------------+
              +---+   Worker   |
                  +------------+
```

Enabling this mode can be done by selecting `<disabled>` when the installer asks for the second interface. The network settings are applied as follows:

```
if public network enabled:
    controller gateway = set via DHCP or statically, routes through the public interface
    worker gateway = set statically by user (defaults to controller's private IP)
    NAT is enabled on controller
else:
    controller gateway = set statically by user (no default)
    worker gateway = same value as controller gateway
    NAT is disabled on the controller
```
