### PR TITLE
Added 'localhost' and 127.0.0.1 to the controller's TLS cert.

### DIFF
--- a/components/installer/pkg/crypto.go
+++ b/components/installer/pkg/crypto.go
@@ -135,6 +135,8 @@ func createAPIServerCSR(ctx *InstallerContext) (csrBytes, keyBytes []byte, errOu
 		Hosts: []string{
 			ctx.Responses.ControllerIP,
 			ctx.Responses.KubeAPIServiceIP,
+			"127.0.0.1",
+			"localhost",
 			"kubernetes.default.svc",
 		},
 		CN: fmt.Sprintf("%s (Controller Server)", ctx.Responses.OrgInfo.Cluster),

--- a/components/waterfront/server/pkg/waterfront/clientcert.go
+++ b/components/waterfront/server/pkg/waterfront/clientcert.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 func MakeGenClientCertHandler(teamsterAddr string) http.Handler {
@@ -33,6 +34,7 @@ func MakeGenClientCertHandler(teamsterAddr string) http.Handler {
 		q := getURL.Query()
 		q.Set("user", "admin")
 		q.Add("group", "admin")
+		q.Set("host", strings.SplitN(r.Host, ":", 2)[0])
 		getURL.RawQuery = q.Encode()
 
 		resp, err := http.Get(getURL.String())


### PR DESCRIPTION
This change also uses the Host header sent to Waterfront as the hostname of the Kubernetes API server in the kubeconfig that is generated via the credentials download.

This makes VM port-forwarding scenarios possible, for example when using a NAT network with VirtualBox.